### PR TITLE
Fix : memory allocation method

### DIFF
--- a/data_structures/graphs/kruskal.c
+++ b/data_structures/graphs/kruskal.c
@@ -27,11 +27,11 @@ struct Graph
 // Creates a graph with V vertices and E edges
 struct Graph *createGraph(int V, int E)
 {
-    struct Graph *graph = new Graph();
+    struct Graph* graph = (struct Graph*)(malloc(sizeof(struct Graph)));
     graph->V = V;
     graph->E = E;
 
-    graph->edge = new Edge[E];
+    graph->edge = (struct Edge*)malloc(sizeof( struct Edge)*E);
 
     return graph;
 }


### PR DESCRIPTION
#### Description of Change
"new" is not used in C , because of that the compiler was giving compilation error.
Instead malloc was used for memory allocation.


#### References


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines]
- [x] Added tests and example, test must pass
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines]
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes:  memory allocation is corrected
